### PR TITLE
Add a separator in the world map tracking options dropdown

### DIFF
--- a/src/map.lua
+++ b/src/map.lua
@@ -35,6 +35,15 @@ function Me.Map_Init()
 	hooksecurefunc( WorldMapFrame.overlayFrames[2], "InitializeDropDown",
 		function()
 			Me.DebugLog2( "WorldMap tracking opened." )
+
+			UIDropDownMenu_AddSeparator()
+
+			local titleInfo = UIDropDownMenu_CreateInfo()
+			titleInfo.isTitle = true
+			titleInfo.notCheckable = true
+			titleInfo.text = L.CROSS_RP
+			UIDropDownMenu_AddButton(titleInfo)
+
 			local info = UIDropDownMenu_CreateInfo();
 			info.isNotRadio = true
 			info.text       = L.MAP_TRACKING_CROSSRP_PLAYERS;


### PR DESCRIPTION
Add separator in world map tracking dropdown to avoid confusion with the previous option group.

![image](https://user-images.githubusercontent.com/34239920/104855536-a73a6100-590d-11eb-8d5a-25c7e5b9eab5.png)


